### PR TITLE
Enable git:// based urls

### DIFF
--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -27,7 +27,7 @@ function findModulesFromGit(modulePath, callback) {
 	if (typeof packageJson._from != "string") {
 		return;
 	}
-	var match = packageJson._from.match(/^([^@]+)@git\+ssh:/);
+	var match = packageJson._from.match(/^([^@]+)@git(\+ssh)?:/);
 	if (match == null) {
 		return;
 	}


### PR DESCRIPTION
This is to make both git:// and git+ssh:// based urls work.
