### PR TITLE
Skip invalid package.json files

### DIFF
--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -20,15 +20,16 @@ function findModulesFromGit(modulePath, callback) {
 	if (! fs.existsSync(modulePath + "/package.json")) {
 		return;
 	}
-	// read and parse
+	
+	// read package.json
 	var packageJsonSrc = fs.readFileSync(modulePath + "/package.json", { encoding: "utf-8" });
+	
+	// try to parse package.json
 	try {
 		var packageJson = JSON.parse(packageJsonSrc);
 	} catch (error) {
-		// Handle invalid package.json files. Simply return
-		console.warn("Error parsing " + modulePath + "/package.json");
-		console.warn(error);
-		return;
+		// throw a better error for parsing
+		throw new Error("Error parsing " + modulePath + "/package.json. Invalid file.");
 	}
 
 	// skip if is not a git-based module

--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -26,10 +26,11 @@ function findModulesFromGit(modulePath, callback) {
 		var packageJson = JSON.parse(packageJsonSrc);
 	} catch (error) {
 		// Handle invalid package.json files. Simply return
+		console.warn("Error parsing " + modulePath + "/package.json");
 		console.warn(error);
 		return;
 	}
-	
+
 	// skip if is not a git-based module
 	if (typeof packageJson._from != "string") {
 		return;

--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -22,7 +22,14 @@ function findModulesFromGit(modulePath, callback) {
 	}
 	// read and parse
 	var packageJsonSrc = fs.readFileSync(modulePath + "/package.json", { encoding: "utf-8" });
-	var packageJson = JSON.parse(packageJsonSrc);
+	try {
+		var packageJson = JSON.parse(packageJsonSrc);
+	} catch (error) {
+		// Handle invalid package.json files. Simply return
+		console.warn(error);
+		return;
+	}
+	
 	// skip if is not a git-based module
 	if (typeof packageJson._from != "string") {
 		return;


### PR DESCRIPTION
We had problems with invalid package.json files due to network failures etc. This caused npm install to completely fail. This path skips invalid package.json files but reports these errors to the console.
