### PR TITLE
Processing a different case of package info

### DIFF
--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -28,13 +28,21 @@ function findModulesFromGit(modulePath, callback) {
 		return;
 	}
 	var match = packageJson._from.match(/^([^@]+)@git(\+ssh|\+https?)?:/);
-	if (match == null) {
-		return;
+	var moduleName = null;
+	if (match !== null) {
+		moduleName = match[1];
+	} else {
+		var matchResolved = packageJson._resolved.match(/^git(\+ssh|\+https?)?:/);
+		if (matchResolved === null) {
+			return;
+		}
+
+		match = packageJson._resolved.split('/');
+		moduleName = match[match.length-1].split('#')[0];
 	}
-	var moduleName = match[1];
 	var moduleVersion = packageJson.version;
 	// notify the callback
-	callback(match[1], moduleVersion, modulePath);
+	callback(moduleName, moduleVersion, modulePath);
 }
 
 function rmdir_r(dirPath) {


### PR DESCRIPTION
I found a different case of package info which is installed from git like below. 

```js
{
  _id: 'a-package@0.1.0',
  _shasum: 'ed034622de6e086ed126e01eb03390823f1e7dc5',
  _from: '../../../../../../tmp/npm-84169-30cf5a30/1419842545049-0.7846870112698525/d0926e934fd9bd5d9a747112a85b7eae5e936157',
  _resolved: 'git+ssh://git@github.com:jin/a-package.git#d0926e934fd9bd5d9a747112a85b7eae5e936157' 
}
```

But **force-dedupe-git-module** refers only the **_from** information. So I added some code for processing with **_resolved** info.