### PR TITLE
Fixed raising module names as a git name

### DIFF
--- a/bin/force-dedupe-git-modules
+++ b/bin/force-dedupe-git-modules
@@ -27,27 +27,46 @@ function findModulesFromGit(modulePath, callback) {
 	if (typeof packageJson._from != "string") {
 		return;
 	}
-	var match = packageJson._from.match(/^([^@]+)@git(\+ssh|\+https?)?:/);
-	var moduleName = null;
-	if (match !== null) {
-		moduleName = match[1];
-	} else if (packageJson._resolved) {
-		var matchResolved = packageJson._resolved.match(/^git(\+ssh|\+https?)?:/);
-		if (matchResolved === null) {
-			return;
-		}
 
-		match = packageJson._resolved.split('/');
-		moduleName = match[match.length-1].split('#')[0];
-	}
+	var moduleName = packageJson.name;
+	var moduleVersion = packageJson.version;
 
-	if (match === null) {
+	if (!isGitModule(packageJson)) {
 		return;
 	}
 
-	var moduleVersion = packageJson.version;
+	if (typeof moduleName === "string") {
+		return callback(moduleName, moduleVersion, modulePath);
+	}
+
+	moduleName = getModuleName(packageJson);
+
 	// notify the callback
 	callback(moduleName, moduleVersion, modulePath);
+}
+
+function getModuleName(packageJson) {
+	var match = packageJson._from.match(/^([^@]+)@git(\+ssh|\+https?)?:/);
+	if (match !== null) {
+		return match[1];
+	}
+
+	match = packageJson._resolved.split('/');
+	return match[match.length-1].split('#')[0];
+}
+
+function isGitModule(packageJson) {
+	if (packageJson._from &&
+		  packageJson._from.match(/^([^@]+)@git(\+ssh|\+https?)?:/) !== null) {
+		return true;
+	}
+
+	if (packageJson._resolved &&
+		  packageJson._resolved.match(/^git(\+ssh|\+https?)?:/) !== null) {
+		return true;
+	}
+
+	return false;
 }
 
 function rmdir_r(dirPath) {
@@ -65,6 +84,7 @@ function rmdir_r(dirPath) {
 
 function main() {
 	findModulesFromGit(".", function (name, version, path) {
+		console.log(name, path);
 		if (path.match(/^.(\/node_modules\/[^/]+|)$/)) {
 			console.log("preserving git-based module: " + name + " at " + path);
 			return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "force-dedupe-git-modules",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "forcibly dedupes the git-based NPM modules in node_modules",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
There is a bug during raising module like;

node_modules/a-mod to node_modules/a-mod.git

Because it makes raising name from git uri.

So I fixed this using a "name" attribute of packageJson.
